### PR TITLE
Fixes

### DIFF
--- a/template_binary/inlist_pgstar
+++ b/template_binary/inlist_pgstar
@@ -73,8 +73,8 @@ Kipp_mass_min = 0
 Kipp_show_mass_boundaries = .true.
 
 ! x axis limits
-Kipp_xmax = -101              ! maximum step number.  negative means use default.
-Kipp_xmin = 0         ! minimum step number.  negative means use default.
+Kipp_xmax = -101d0              ! maximum step number.  negative means use default.
+Kipp_xmin = -101d0         ! minimum step number.  negative means use default.
 Kipp_max_width = 2000         ! only used if > 0.  causes xmin to move with xmax.
 
 Kipp_show_mixing = .true.

--- a/template_binary/src/run_binary_extras.f90
+++ b/template_binary/src/run_binary_extras.f90
@@ -377,6 +377,7 @@ contains
     type (binary_info), pointer :: b
     integer, intent(in) :: binary_id
     integer, intent(out) :: ierr
+    character (len=200) :: fname
     call binary_ptr(binary_id, b, ierr)
     if (ierr /= 0) then ! failure in  binary_ptr
        return

--- a/template_single_remove_envelope/inlist_to_cc
+++ b/template_single_remove_envelope/inlist_to_cc
@@ -61,7 +61,7 @@ Pvsc_zsh                                        = 0.1d0
 
 ! drag to prevent the development of radial pulses.
 use_drag_energy                                 = .false. ! means don't include energy from drag in energy equation
-drag_coefficient                                = 1.0d0
+drag_coefficient                                = 0.5d0
 min_q_for_drag                                  = 0.8d0
 
 ! wind


### PR DESCRIPTION
tweaks to fix the pgstar, prevent shell mergers by lowering overshoot for burn_Z, ensure a mod file is saved if the model terminates prematurely, reduce the drag coefficient.